### PR TITLE
Swagger 2 demonstration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-target
+target/
 .metadata
 .settings
 .classpath
@@ -10,4 +10,5 @@ target
 *.ear
 *.iml
 *.uml
-.idea
+.idea/
+

--- a/v2.spec/backend-services/memory-service/pom.xml
+++ b/v2.spec/backend-services/memory-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.sandcastle.microservices</groupId>
     <artifactId>memory-service</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <properties>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sandcastle.apps.swagger</groupId>
             <artifactId>web-services-models</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -102,6 +102,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <version>0.14.1</version>
                 <configuration>
                     <images>
                         <image>

--- a/v2.spec/backend-services/memory-service/pom.xml
+++ b/v2.spec/backend-services/memory-service/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.sandcastle.microservices</groupId>
+    <artifactId>memory-service</artifactId>
+    <version>0.0.1</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <!-- Project -->
+        <jetty-maven-plugin.version>9.3.7.v20160115</jetty-maven-plugin.version>
+        <jetty.http.port>8080</jetty.http.port>
+        <maven-compiler-plugin.version>3.5</maven-compiler-plugin.version>
+        <maven-war-plugin.version>2.6</maven-war-plugin.version>
+        <servlet-version>2.5</servlet-version>
+        <jackson-version>2.6.3</jackson-version>
+        <fabric8.version>2.2.98</fabric8.version>
+        <lombok.version>1.16.16</lombok.version>
+
+        <!-- Docker-->
+        <docker.from>fabric8/tomcat-8.0</docker.from>
+        <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+        <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
+        <docker.port.container.jolokia>8778</docker.port.container.jolokia>
+        <docker.port.container.http>${jetty.http.port}</docker.port.container.http>
+
+
+        <!-- Fabric8/Kubernetes/OpenShift-->
+        <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
+        <fabric8.service.name>${project.artifactId}</fabric8.service.name>
+        <fabric8.service.port>80</fabric8.service.port>
+        <fabric8.service.containerPort>${jetty.http.port}</fabric8.service.containerPort>
+        <fabric8.service.type>LoadBalancer</fabric8.service.type>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>${servlet-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sandcastle.apps.swagger</groupId>
+            <artifactId>web-services-models</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${maven-war-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty-maven-plugin.version}</version>
+                <configuration>
+                    <httpConnector>
+                        <!--host>localhost</host-->
+                        <port>${jetty.http.port}</port>
+                    </httpConnector>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>fabric8-maven-plugin</artifactId>
+                <version>2.2.100</version>
+                <executions>
+                    <execution>
+                        <id>json</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>json</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>attach</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>${docker.image}</name>
+                            <build>
+                                <from>${docker.from}</from>
+                                <assembly>
+                                    <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                                </assembly>
+                                <env>
+                                    <CATALINA_OPTS>-javaagent:/opt/tomcat/jolokia-agent.jar=host=0.0.0.0,port=8778</CATALINA_OPTS>
+                                </env>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>f8-build</id>
+            <build>
+                <defaultGoal>clean install docker:build fabric8:json</defaultGoal>
+            </build>
+        </profile>
+        <profile>
+            <id>f8-deploy</id>
+            <build>
+                <defaultGoal>clean install docker:build docker:push fabric8:json fabric8:apply</defaultGoal>
+            </build>
+            <properties>
+                <fabric8.recreate>true</fabric8.recreate>
+                <fabric8.imagePullPolicySnapshot>Always</fabric8.imagePullPolicySnapshot>
+            </properties>
+        </profile>
+        <profile>
+            <id>f8-local-deploy</id>
+            <build>
+                <defaultGoal>clean install docker:build fabric8:json fabric8:apply</defaultGoal>
+            </build>
+            <properties>
+                <fabric8.recreate>true</fabric8.recreate>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/v2.spec/backend-services/memory-service/src/main/java/org/sandcastle/apps/services/dto/MemoryResponseDTO.java
+++ b/v2.spec/backend-services/memory-service/src/main/java/org/sandcastle/apps/services/dto/MemoryResponseDTO.java
@@ -1,0 +1,12 @@
+package org.sandcastle.apps.services.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.sandcastle.apps.dto.ResponseDTO;
+import org.sandcastle.apps.models.Memory;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class MemoryResponseDTO extends ResponseDTO<Memory> {
+    private static final long serialVersionUID = -4851666122472660982L;
+}

--- a/v2.spec/backend-services/memory-service/src/main/java/org/sandcastle/apps/services/internal/MemoryServiceHttpServlet.java
+++ b/v2.spec/backend-services/memory-service/src/main/java/org/sandcastle/apps/services/internal/MemoryServiceHttpServlet.java
@@ -1,0 +1,46 @@
+package org.sandcastle.apps.services.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.sandcastle.apps.models.Memory;
+import org.sandcastle.apps.services.dto.MemoryResponseDTO;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class MemoryServiceHttpServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -7131719499043898544L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.doGet(req, resp);
+        resp.setContentType("application/json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        MemoryResponseDTO response = new MemoryResponseDTO();
+        response.setTime(System.currentTimeMillis());
+        response.setIp(getIpAddress());
+        Memory memory = new Memory();
+        response.setData(memory);
+
+        PrintWriter out = resp.getWriter();
+        mapper.writerWithDefaultPrettyPrinter().writeValue(out, resp);
+    }
+
+    private String getIpAddress() {
+        String hostName;
+        try {
+            hostName = InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            hostName = "unknown";
+        }
+        return hostName;
+    }
+}

--- a/v2.spec/backend-services/memory-service/src/main/webapp/WEB-INF/web.xml
+++ b/v2.spec/backend-services/memory-service/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <servlet>
+        <display-name>MemoryServiceHttpServlet</display-name>
+        <servlet-name>MemoryServiceHttpServlet</servlet-name>
+        <servlet-class>org.sandcastle.apps.services.internal.MemoryServiceHttpServlet</servlet-class>
+    </servlet>
+
+
+    <servlet-mapping>
+        <servlet-name>MemoryServiceHttpServlet</servlet-name>
+        <url-pattern>/api/backend/memory</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/v2.spec/backend-services/person-service/pom.xml
+++ b/v2.spec/backend-services/person-service/pom.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.sandcastle.microservices</groupId>
+    <artifactId>person-service</artifactId>
+    <version>0.0.1</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <!-- Project -->
+        <jetty-maven-plugin.version>9.3.7.v20160115</jetty-maven-plugin.version>
+        <jetty.http.port>8080</jetty.http.port>
+        <maven-compiler-plugin.version>3.5</maven-compiler-plugin.version>
+        <maven-war-plugin.version>2.6</maven-war-plugin.version>
+        <servlet-version>2.5</servlet-version>
+        <jackson-version>2.6.3</jackson-version>
+        <fabric8.version>2.2.98</fabric8.version>
+        <lombok.version>1.16.16</lombok.version>
+
+        <!-- Docker-->
+        <docker.from>fabric8/tomcat-8.0</docker.from>
+        <docker.image>${fabric8.dockerUser}${project.artifactId}:${project.version}</docker.image>
+        <docker.assemblyDescriptorRef>rootWar</docker.assemblyDescriptorRef>
+        <docker.port.container.jolokia>8778</docker.port.container.jolokia>
+        <docker.port.container.http>${jetty.http.port}</docker.port.container.http>
+
+
+        <!-- Fabric8/Kubernetes/OpenShift-->
+        <fabric8.dockerUser>fabric8/</fabric8.dockerUser>
+        <fabric8.service.name>${project.artifactId}</fabric8.service.name>
+        <fabric8.service.port>80</fabric8.service.port>
+        <fabric8.service.containerPort>${jetty.http.port}</fabric8.service.containerPort>
+        <fabric8.service.type>LoadBalancer</fabric8.service.type>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>${servlet-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sandcastle.apps.swagger</groupId>
+            <artifactId>web-services-models</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${maven-war-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty-maven-plugin.version}</version>
+                <configuration>
+                    <httpConnector>
+                        <!--host>localhost</host-->
+                        <port>${jetty.http.port}</port>
+                    </httpConnector>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>fabric8-maven-plugin</artifactId>
+                <version>2.2.100</version>
+                <executions>
+                    <execution>
+                        <id>json</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>json</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>attach</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>${docker.image}</name>
+                            <build>
+                                <from>${docker.from}</from>
+                                <assembly>
+                                    <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                                </assembly>
+                                <env>
+                                    <CATALINA_OPTS>-javaagent:/opt/tomcat/jolokia-agent.jar=host=0.0.0.0,port=8778</CATALINA_OPTS>
+                                </env>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>f8-build</id>
+            <build>
+                <defaultGoal>clean install docker:build fabric8:json</defaultGoal>
+            </build>
+        </profile>
+        <profile>
+            <id>f8-deploy</id>
+            <build>
+                <defaultGoal>clean install docker:build docker:push fabric8:json fabric8:apply</defaultGoal>
+            </build>
+            <properties>
+                <fabric8.recreate>true</fabric8.recreate>
+                <fabric8.imagePullPolicySnapshot>Always</fabric8.imagePullPolicySnapshot>
+            </properties>
+        </profile>
+        <profile>
+            <id>f8-local-deploy</id>
+            <build>
+                <defaultGoal>clean install docker:build fabric8:json fabric8:apply</defaultGoal>
+            </build>
+            <properties>
+                <fabric8.recreate>true</fabric8.recreate>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/v2.spec/backend-services/person-service/pom.xml
+++ b/v2.spec/backend-services/person-service/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.sandcastle.microservices</groupId>
     <artifactId>person-service</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <properties>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.sandcastle.apps.swagger</groupId>
             <artifactId>web-services-models</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
@@ -102,6 +102,7 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
+                <version>0.14.1</version>
                 <configuration>
                     <images>
                         <image>

--- a/v2.spec/backend-services/person-service/src/main/java/org/sandcastle/apps/services/dto/PersonResponseDTO.java
+++ b/v2.spec/backend-services/person-service/src/main/java/org/sandcastle/apps/services/dto/PersonResponseDTO.java
@@ -1,0 +1,12 @@
+package org.sandcastle.apps.services.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.sandcastle.apps.dto.ResponseDTO;
+import org.sandcastle.apps.models.Person;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class PersonResponseDTO extends ResponseDTO<Person> {
+    private static final long serialVersionUID = 6548255564808717337L;
+}

--- a/v2.spec/backend-services/person-service/src/main/java/org/sandcastle/apps/services/internal/PersonServiceHttpServlet.java
+++ b/v2.spec/backend-services/person-service/src/main/java/org/sandcastle/apps/services/internal/PersonServiceHttpServlet.java
@@ -1,0 +1,46 @@
+package org.sandcastle.apps.services.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.sandcastle.apps.models.Person;
+import org.sandcastle.apps.services.dto.PersonResponseDTO;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class PersonServiceHttpServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -3112981464412978587L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.doGet(req, resp);
+        resp.setContentType("application/json");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        PersonResponseDTO response = new PersonResponseDTO();
+        response.setTime(System.currentTimeMillis());
+        response.setIp(getIpAddress());
+        Person person = new Person();
+        response.setData(person);
+
+        PrintWriter out = resp.getWriter();
+        mapper.writerWithDefaultPrettyPrinter().writeValue(out, resp);
+    }
+
+    private String getIpAddress() {
+        String hostName;
+        try {
+            hostName = InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            hostName = "unknown";
+        }
+        return hostName;
+    }
+}

--- a/v2.spec/backend-services/person-service/src/main/webapp/WEB-INF/web.xml
+++ b/v2.spec/backend-services/person-service/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <servlet>
+        <display-name>PersonServiceHttpServlet</display-name>
+        <servlet-name>PersonServiceHttpServlet</servlet-name>
+        <servlet-class>org.sandcastle.apps.services.internal.PersonServiceHttpServlet</servlet-class>
+    </servlet>
+
+
+    <servlet-mapping>
+        <servlet-name>PersonServiceHttpServlet</servlet-name>
+        <url-pattern>/api/backend/person</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/v2.spec/pom.xml
+++ b/v2.spec/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.sandcastle.microservices</groupId>
+    <artifactId>swagger.v2.spec.demo.parent</artifactId>
+    <version>0.0.1</version>
+    <packaging>pom</packaging>
+
+    <name>Swagger v2 Demo Application</name>
+
+    <modules>
+        <module>web-services-models</module>
+        <module>web-services</module>
+        <module>backend-services/person-service</module>
+        <module>backend-services/memory-service</module>
+    </modules>
+</project>

--- a/v2.spec/pom.xml
+++ b/v2.spec/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sandcastle.microservices</groupId>
     <artifactId>swagger.v2.spec.demo.parent</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Swagger v2 Demo Application</name>

--- a/v2.spec/ribbon-service-account.yml
+++ b/v2.spec/ribbon-service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ribbon

--- a/v2.spec/web-services-models/pom.xml
+++ b/v2.spec/web-services-models/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sandcastle.microservices</groupId>
+        <artifactId>swagger.v2.spec.demo.parent</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <groupId>org.sandcastle.apps.swagger</groupId>
+    <artifactId>web-services-models</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Application models</name>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <lombok.version>1.16.16</lombok.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/v2.spec/web-services-models/pom.xml
+++ b/v2.spec/web-services-models/pom.xml
@@ -5,12 +5,13 @@
     <parent>
         <groupId>org.sandcastle.microservices</groupId>
         <artifactId>swagger.v2.spec.demo.parent</artifactId>
-        <version>0.0.1</version>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.sandcastle.apps.swagger</groupId>
     <artifactId>web-services-models</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
     <name>Application models</name>
 
     <properties>

--- a/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/dto/ResponseDTO.java
+++ b/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/dto/ResponseDTO.java
@@ -1,0 +1,14 @@
+package org.sandcastle.apps.dto;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class ResponseDTO<T> implements Serializable {
+    private static final long serialVersionUID = -4422507735400345361L;
+
+    private T data;
+    private long time;
+    private String ip;
+}

--- a/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/models/Memories.java
+++ b/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/models/Memories.java
@@ -1,0 +1,4 @@
+package org.sandcastle.apps.models;
+
+public class Memories {
+}

--- a/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/models/Memory.java
+++ b/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/models/Memory.java
@@ -1,0 +1,4 @@
+package org.sandcastle.apps.models;
+
+public class Memory {
+}

--- a/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/models/Person.java
+++ b/v2.spec/web-services-models/src/main/java/org/sandcastle/apps/models/Person.java
@@ -1,0 +1,11 @@
+package org.sandcastle.apps.models;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class Person implements Serializable {
+    private String name;
+    private String surname;
+}

--- a/v2.spec/web-services/pom.xml
+++ b/v2.spec/web-services/pom.xml
@@ -1,0 +1,190 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.5.4.RELEASE</version>
+    </parent>
+
+    <groupId>org.sandcastle.apps.swagger</groupId>
+    <artifactId>second-spec</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+    <name>Web Services</name>
+
+    <properties>
+        <start-class>org.sandcastle.apps.Application</start-class>
+        <java.version>1.8</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <swagger2.version>2.7.0</swagger2.version>
+        <hystrix.version>1.5.1</hystrix.version>
+        <ribbon.version>2.1.2</ribbon.version>
+        <kubeflix.version>1.0.15</kubeflix.version>
+
+        <!-- Docker-->
+        <docker.assemblyDescriptorRef>artifact</docker.assemblyDescriptorRef>
+        <docker.from>docker.io/fabric8/java-jboss-openjdk8-jdk:1.0.10</docker.from>
+        <docker.image>fabric8/${project.artifactId}:${project.version}</docker.image>
+        <docker.port.container.http>8080</docker.port.container.http>
+        <docker.port.container.jolokia>8778</docker.port.container.jolokia>
+
+        <!-- Fabric8/Kubernetes/OpenShift-->
+        <fabric8.iconRef>icons/spring-boot</fabric8.iconRef>
+        <fabric8.readinessProbe.httpGet.path>/health</fabric8.readinessProbe.httpGet.path>
+        <fabric8.readinessProbe.httpGet.port>8080</fabric8.readinessProbe.httpGet.port>
+        <fabric8.readinessProbe.initialDelaySeconds>5</fabric8.readinessProbe.initialDelaySeconds>
+        <fabric8.readinessProbe.timeoutSeconds>30</fabric8.readinessProbe.timeoutSeconds>
+        <fabric8.service.containerPort>8080</fabric8.service.containerPort>
+        <fabric8.service.name>second-spec</fabric8.service.name>
+        <fabric8.service.port>80</fabric8.service.port>
+        <fabric8.service.type>LoadBalancer</fabric8.service.type>
+        <fabric8.serviceAccount>ribbon</fabric8.serviceAccount>
+        <fabric8.env.MEMORY_BACKENDSERVICEHOST>backend/memory</fabric8.env.MEMORY_BACKENDSERVICEHOST>
+        <fabric8.env.MEMORY_BACKENDSERVICEPORT>80</fabric8.env.MEMORY_BACKENDSERVICEPORT>
+        <fabric8.env.PERSON_BACKENDSERVICEHOST>backend/person</fabric8.env.PERSON_BACKENDSERVICEHOST>
+        <fabric8.env.PERSON_BACKENDSERVICEPORT>80</fabric8.env.PERSON_BACKENDSERVICEPORT>
+        <fabric8.env.USE_KUBERNETES_DISCOVERY>true</fabric8.env.USE_KUBERNETES_DISCOVERY>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>${swagger2.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>${swagger2.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+            <version>${hystrix.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-metrics-event-stream</artifactId>
+            <version>${hystrix.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.ribbon</groupId>
+            <artifactId>ribbon-core</artifactId>
+            <version>${ribbon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netflix.ribbon</groupId>
+            <artifactId>ribbon-loadbalancer</artifactId>
+            <version>${ribbon.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8.kubeflix</groupId>
+            <artifactId>ribbon-discovery</artifactId>
+            <version>${kubeflix.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.sandcastle.apps.swagger</groupId>
+            <artifactId>web-services-models</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.14.2</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>${docker.image}</name>
+                            <build>
+                                <from>${docker.from}</from>
+                                <assembly>
+                                    <basedir>/app</basedir>
+                                    <descriptorRef>${docker.assemblyDescriptorRef}</descriptorRef>
+                                </assembly>
+                                <env>
+                                    <JAR>${project.artifactId}-${project.version}.war</JAR>
+                                    <JAVA_OPTIONS>-Djava.security.egd=/dev/./urandom</JAVA_OPTIONS>
+                                </env>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>fabric8-maven-plugin</artifactId>
+                <version>2.2.100</version>
+                <executions>
+                    <execution>
+                        <id>json</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>json</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>attach</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>f8-build</id>
+            <build>
+                <defaultGoal>clean install docker:build fabric8:json</defaultGoal>
+            </build>
+        </profile>
+        <profile>
+            <id>f8-deploy</id>
+            <build>
+                <defaultGoal>clean install docker:build docker:push fabric8:json fabric8:apply</defaultGoal>
+            </build>
+            <properties>
+                <fabric8.recreate>true</fabric8.recreate>
+                <fabric8.imagePullPolicySnapshot>Always</fabric8.imagePullPolicySnapshot>
+            </properties>
+        </profile>
+        <profile>
+            <id>f8-local-deploy</id>
+            <build>
+                <defaultGoal>clean install docker:build fabric8:json fabric8:apply</defaultGoal>
+            </build>
+            <properties>
+                <fabric8.recreate>true</fabric8.recreate>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/v2.spec/web-services/pom.xml
+++ b/v2.spec/web-services/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.sandcastle.apps.swagger</groupId>
     <artifactId>second-spec</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Web Services</name>
 
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.sandcastle.apps.swagger</groupId>
             <artifactId>web-services-models</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/v2.spec/web-services/src/main/java/org/sandcastle/apps/Application.java
+++ b/v2.spec/web-services/src/main/java/org/sandcastle/apps/Application.java
@@ -1,0 +1,67 @@
+package org.sandcastle.apps;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import static springfox.documentation.builders.PathSelectors.regex;
+
+@SpringBootApplication
+@EnableConfigurationProperties
+@EnableSwagger2
+@ComponentScan("org.sandcastle.apps")
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public Docket personApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("person")
+                .apiInfo(personApiInfo())
+                .select()
+                .paths(regex("/person.*"))
+                .build();
+    }
+
+    @Bean
+    public Docket memoryApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .groupName("memory")
+                .apiInfo(memoryApiInfo())
+                .select()
+                .paths(regex("/memory.*"))
+                .build();
+    }
+
+    private ApiInfo personApiInfo(){
+        return new ApiInfoBuilder()
+                .title("Person Api")
+                .description("Spring based RESTful Api for genealogy ")
+                .termsOfServiceUrl("")
+                .contact(new Contact("Saumil Patel", null, null))
+                .license("Apache License version 2.0")
+                .version("2.0")
+                .build();
+    }
+
+    private ApiInfo memoryApiInfo(){
+        return new ApiInfoBuilder()
+                .title("Memory Api")
+                .description("Spring based RESTful Api for genealogy ")
+                .termsOfServiceUrl("")
+                .contact(new Contact("Saumil Patel", null, null))
+                .license("Apache License version 2.0")
+                .version("2.0")
+                .build();
+    }
+}

--- a/v2.spec/web-services/src/main/java/org/sandcastle/apps/api/MemoryController.java
+++ b/v2.spec/web-services/src/main/java/org/sandcastle/apps/api/MemoryController.java
@@ -1,0 +1,33 @@
+package org.sandcastle.apps.api;
+
+import org.sandcastle.apps.commands.MemoriesCommand;
+import org.sandcastle.apps.models.Memories;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/api")
+@ConfigurationProperties(prefix = "memories")
+public class MemoryController {
+
+    private RestTemplate template = new RestTemplate();
+    private String memoryServiceHost;
+    private int memoryServicePort;
+
+    @GetMapping(value = "/memories", produces = "application/json")
+    public Memories getMemories() {
+        return null;
+    }
+
+    @GetMapping(value = "/memories/{mid}", produces = "application/json")
+    public Memories findMemories(@PathVariable String mid) {
+        MemoriesCommand memoryCommand = new MemoriesCommand(memoryServiceHost, memoryServicePort)
+                .withMemoryId(mid)
+                .withTemplate(template);
+        return memoryCommand.execute();
+    }
+}

--- a/v2.spec/web-services/src/main/java/org/sandcastle/apps/api/PersonController.java
+++ b/v2.spec/web-services/src/main/java/org/sandcastle/apps/api/PersonController.java
@@ -1,0 +1,28 @@
+package org.sandcastle.apps.api;
+
+import org.sandcastle.apps.commands.PersonCommand;
+import org.sandcastle.apps.models.Person;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/api")
+@ConfigurationProperties(prefix = "person")
+public class PersonController {
+
+    private RestTemplate template = new RestTemplate();
+    private String personServiceHost;
+    private int personServicePort;
+
+    @GetMapping(value = "/person/{personId}", produces = "application/json")
+    public Person findPerson(@PathVariable String personId){
+        PersonCommand personCommand = new PersonCommand(personServiceHost, personServicePort)
+                .withPersonId(personId)
+                .withTemplate(template);
+        return personCommand.execute();
+    }
+}

--- a/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/ApplicationBackendCommand.java
+++ b/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/ApplicationBackendCommand.java
@@ -1,0 +1,58 @@
+package org.sandcastle.apps.commands;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestTemplate;
+
+public abstract class ApplicationBackendCommand<T, R extends ApplicationBackendCommand> extends HystrixCommand<T> {
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private RestTemplate template;
+    private String host;
+    private int port;
+
+    ApplicationBackendCommand(String host, int port) {
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("wildflyswarm.backend"))
+                .andThreadPoolPropertiesDefaults(
+                        HystrixThreadPoolProperties.Setter()
+                                .withCoreSize(10)
+                                .withMaxQueueSize(-1)
+                )
+                .andCommandPropertiesDefaults(
+                        HystrixCommandProperties.Setter()
+                                .withCircuitBreakerEnabled(true)
+                                .withCircuitBreakerRequestVolumeThreshold(5)
+                                .withMetricsRollingStatisticalWindowInMilliseconds(5000)
+                )
+        );
+        this.host = host;
+        this.port = port;
+    }
+
+    protected abstract R self();
+
+    public R withTemplate(RestTemplate template) {
+        this.template = template;
+        return self();
+    }
+
+    protected String getHost() {
+        return host;
+    }
+
+    protected int getPort() {
+        return port;
+    }
+
+    protected void setTemplate(RestTemplate template) {
+        this.template = template;
+    }
+
+    protected RestTemplate getTemplate() {
+        return template;
+    }
+}

--- a/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/MemoriesCommand.java
+++ b/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/MemoriesCommand.java
@@ -1,0 +1,34 @@
+package org.sandcastle.apps.commands;
+
+import org.sandcastle.apps.models.Memories;
+
+public class MemoriesCommand extends ApplicationBackendCommand<Memories, MemoriesCommand> {
+    private String memoryId;
+
+    public MemoriesCommand(String host, int port) {
+        super(host, port);
+    }
+
+    @Override
+    protected MemoriesCommand self() {
+        return this;
+    }
+
+    public MemoriesCommand withMemoryId(String memoryId) {
+        this.memoryId = memoryId;
+        return this;
+    }
+
+    @Override
+    protected Memories run() throws Exception {
+        String memoryBackendServiceUrl = String.format("http://%s:%d/api/backend/memory?memory={memoryId}", getHost(), getPort());
+        log.info("Sending to : {}", memoryBackendServiceUrl);
+        return getTemplate().getForObject(memoryBackendServiceUrl, Memories.class, memoryId);
+    }
+
+    @Override
+    protected Memories getFallback() {
+        Memories memories = new Memories();
+        return memories;
+    }
+}

--- a/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/MemoryCommand.java
+++ b/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/MemoryCommand.java
@@ -1,0 +1,34 @@
+package org.sandcastle.apps.commands;
+
+import org.sandcastle.apps.models.Memory;
+
+public class MemoryCommand extends ApplicationBackendCommand<Memory, MemoryCommand> {
+    private String memoryId;
+
+    public MemoryCommand(String host, int port) {
+        super(host, port);
+    }
+
+    @Override
+    protected MemoryCommand self() {
+        return this;
+    }
+
+    public MemoryCommand withMemoryId(String memoryId) {
+        this.memoryId = memoryId;
+        return this;
+    }
+
+    @Override
+    protected Memory run() throws Exception {
+        String memoryBackendServiceUrl = String.format("http://%s:%d/api/backend/memory?memory={memoryId}", getHost(), getPort());
+        log.info("Sending to : {}", memoryBackendServiceUrl);
+        return getTemplate().getForObject(memoryBackendServiceUrl, Memory.class, memoryId);
+    }
+
+    @Override
+    protected Memory getFallback() {
+        Memory memory = new Memory();
+        return memory;
+    }
+}

--- a/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/PersonCommand.java
+++ b/v2.spec/web-services/src/main/java/org/sandcastle/apps/commands/PersonCommand.java
@@ -1,0 +1,35 @@
+package org.sandcastle.apps.commands;
+
+import org.sandcastle.apps.models.Person;
+
+public class PersonCommand extends ApplicationBackendCommand<Person, PersonCommand> {
+    private String personId;
+
+    public PersonCommand(String host, int port) {
+        super(host, port);
+    }
+
+    @Override
+    protected PersonCommand self() {
+        return this;
+    }
+
+    public PersonCommand withPersonId(String personId) {
+        this.personId = personId;
+        return this;
+    }
+
+    @Override
+    protected Person run() throws Exception {
+        String personBackendServiceUrl = String.format("http://%s:%d/api/backend/person?person={personId}", getHost(), getPort());
+        log.info("Sending to : {}", personBackendServiceUrl);
+        return getTemplate().getForObject(personBackendServiceUrl, Person.class, personId);
+    }
+
+    @Override
+    protected Person getFallback() {
+        Person person = new Person();
+        person.setName("Saumil");
+        return person;
+    }
+}

--- a/v2.spec/web-services/src/main/resources/applications.properties
+++ b/v2.spec/web-services/src/main/resources/applications.properties
@@ -1,0 +1,5 @@
+person.personServiceHost=localhost
+person.personServicePort=8080
+
+memory.memoryServiceHost=localhost
+memory.memoryServicePort=8080


### PR DESCRIPTION
This feature repository contains demonstration of microservices and associated documentation configurations for swagger v2.

For microservices environment, `docker` and `fabric8` is used while for demonstration reasons `HttpServlet` based backend services are created. All these backend services are wired-in with Hystrix for load balancing reasons.